### PR TITLE
Only set new timeout if it is different from the old one

### DIFF
--- a/python/fibre/serial_transport.py
+++ b/python/fibre/serial_transport.py
@@ -16,7 +16,8 @@ DEFAULT_BAUDRATE = 115200
 
 class SerialStreamTransport(fibre.protocol.StreamSource, fibre.protocol.StreamSink):
     def __init__(self, port, baud):
-        self._dev = serial.Serial(port, baud, timeout=1)
+        self._timeout = 1
+        self._dev = serial.Serial(port, baud, timeout=self._timeout)
 
     def process_bytes(self, bytes):
         self._dev.write(bytes)
@@ -28,10 +29,16 @@ class SerialStreamTransport(fibre.protocol.StreamSource, fibre.protocol.StreamSi
         function blocks forever. A deadline before the current time corresponds
         to non-blocking mode.
         """
-        if deadline is None:
+        # Only set new timeout value if it is reasonably different from the old one (e.g. 20% as below)
+        # Otherwise it adds significant overhead (at least under Win10) as the port is reset with every reconfiguration
+        if deadline is None and self._timeout is not None:
+            self._timeout = None
             self._dev.timeout = None
-        else:
-            self._dev.timeout = max(deadline - time.monotonic(), 0)
+        elif deadline is not None:
+            new_timeout = max(deadline - time.monotonic(), 0)
+            if abs(new_timeout - self._timeout) > self._timeout * 0.2:
+                self._timeout = new_timeout
+                self._dev.timeout = new_timeout
         return self._dev.read(n_bytes)
 
     def get_bytes_or_fail(self, n_bytes, deadline):


### PR DESCRIPTION
A change as discussed in ODrive discord channel. 

Every time the serial port's timeout value is changed, the port is reset (or "reconfigured", as per pyserial documentation), which leads to a significant delay under Windows 10. This workaround makes sure that the timeout value is only changed when the new value differs from the old one by more than a predefined amount (20% in this case). This adds some extra calculations for every read operation, but I didn't notice any slow down in actual operations.

The effect of setting timeout value can be tested with this script: https://github.com/RoCkaZ/random_tests/tree/master/pyserial_timeout_issue